### PR TITLE
Add Customer&Item to seed.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,14 +6,66 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 #
-
 # coding: utf-8
-Customer.create!(firsrt_name: "円盤",
-last_name: "長野",
-firsrt_furighana: "enban",
-last_furigana: "nagano",
-post_code: "000-0000",
-adress: "長野県長野市四丁目",
-phone_number: "000-0000-000",
-email: "nagano@gmail.com",
-password: "password" )
+
+# Customer
+Customer.create!(
+  first_name: "円盤",
+  last_name: "長野",
+  first_furigana: "enban",
+  last_furigana: "nagano",
+  post_code: "000-0000",
+  address: "長野県長野市四丁目",
+  phone_number: "000-0000-000",
+  email: "nagano@gmail.com",
+  password: "password" )
+
+10.times do |n|
+  first_name = Gimei.first.kanji
+  last_name = Gimei.last.kanji
+  first_furigana = Gimei.first.katakana
+  last_furigana = Gimei.last.katakana
+  post_code = "000-0000",
+  address = Gimei.address.kanji
+  phone_number = "000-0000-000",
+  email = "nagano#{n+1}@gmail.com",
+  password = "password"
+
+  Customer.create!(
+  first_name: first_name,
+  last_name: last_name,
+  first_furigana: first_furigana,
+  last_furigana: last_furigana,
+  post_code: post_code,
+  address: address,
+  phone_number: phone_number,
+  email: email,
+  password: password)
+end
+
+#Item
+I18n.locale = 'ja'
+10.times do |n|
+  name  = Faker::Music.album
+  format = "True"
+  artist_id = "#{n+1}"
+  jacket_image = "#{n+1}"
+  genre_id = "#{n+1}"
+  label_id = "#{n+1}"
+  quantity = "#{n+1}"
+  release_date = "2019/11/1"
+  is_selling = "True"
+  prices  = "#{n+1}"
+
+  Item.create!(
+  name: name,
+  format: format,
+  artist_id: artist_id,
+  jacket_image: jacket_image,
+  genre_id: genre_id,
+  label_id: label_id,
+  quantity: quantity,
+  release_date: release_date,
+  is_selling: is_selling,
+  prices: prices)
+end


### PR DESCRIPTION
seed.rbにCustomerとItem追加しました。

【実行コマンド】
$ rails db:migrate:reset
$ rails db:seed

【例】
irb(main):002:0> Customer.first
  Customer Load (0.8ms)  SELECT  "customers".* FROM "customers" ORDER BY "customers"."id" ASC LIMIT ?  [["LIMIT", 1]]
=> #<Customer id: 1, first_name: "円盤", last_name: "長野", first_furigana: "enban", last_furigana: "nagano", post_code: "000-0000", address: "長野県長野市四丁目", phone_number: "000-0000-000", email: "nagano@gmail.com", created_at: "2019-11-12 11:41:36", updated_at: "2019-11-12 11:41:36">
irb(main):003:0> Item.first
  Item Load (0.4ms)  SELECT  "items".* FROM "items" ORDER BY "items"."id" ASC LIMIT ?  [["LIMIT", 1]]
=> #<Item id: 1, name: "X&Y", artist_id: 1, format: true, jacket_image: "1", genre_id: 1, label_id: 1, quantity: 1, release_date: "2019-11-01", is_selling: true, created_at: "2019-11-12 11:41:39", updated_at: "2019-11-12 11:41:39", prices: 1>
irb(main):004:0>