### PR TITLE
ユーザ情報のURL直打ち禁止の機能

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,4 +1,12 @@
 class LikesController < ApplicationController
+  before_action :correct_customer, only: [:index]
+  def correct_customer
+    @customer   = Customer.find(params[:id])
+    @cust_check = current_customer
+    unless @customer == @cust_check
+      redirect_to root_path
+    end
+  end
 
   def index
     @likes = Like.where(customer_id: params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,20 @@
 class UsersController < ApplicationController
-  def show
+
+  before_action :correct_customer, only: [:show, :destroy]
+  def correct_customer
     @customer   = Customer.find(params[:id])
+    @cust_check = current_customer
+    unless @customer == @cust_check
+      redirect_to root_path
+    end
+  end
+
+  def show
     @deliveries = @customer.deliveries
     @delivery   = @customer.deliveries.new
   end
 
-  def edit
-  end
-
-  def update
-  end
-
   def destroy
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,11 +26,9 @@ Rails.application.routes.draw do
     resources :items
   end
 
-  #マイページ閲覧、基本情報の更新/編集、退会、いいね一覧
+  #マイページ閲覧、退会手続き画面、いいね一覧
   scope :users do
     get    '/:id(.:format)',       to: 'users#show',      as: :show_customer
-    patch  '/:id(.:format)',       to: 'users#update',    as: :update_customer
-    get    '/:id/edit(.:format)',  to: 'users#edit',      as: :edit_customer
     delete '/:id(.:format)',       to: 'users#destroy',   as: :destroy_customer
     get    '/:id/likes(.:format)', to: 'likes#index',     as: :likes
   end


### PR DESCRIPTION
マイページやいいね一覧へのURL直打ちを禁止しました。
ログインユーザのみのログインユーザのマイページやいいね一覧が参照できます。
正しくないユーザがURL直打ちすると**ルートパス**(商品一覧)に飛びます。

#### 対応内容
- 下記コントローラでbefore_actionを追加しました
1. likes_controller
1. users_controller

- routes.rbから不要なルーティング（edit,update）を削除しました
ログインユーザのedit,updateはdevise側で制御しているのに、
ルーティングを余分に追加していたので削除しました。



