### PR TITLE
itemモデルのbelogs_toのコメントを外しました

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,8 +4,8 @@ class Item < ApplicationRecord
 	has_many :disks, dependent: :destroy
 	has_many :arrived_items
 	has_many :likes
-	# belongs_to :genre
-	# belongs_to :label
-	# belongs_to :artist
+	belongs_to :genre
+	belongs_to :label
+	belongs_to :artist
 
 end


### PR DESCRIPTION
Itemモデルのbelogs_toがコメントアウトされている件 #41　について対応しました