### PR TITLE
AdminのURL直打ち禁止の設定&パスワード再発行の画面&管理者の編集画面

### DIFF
--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -59,4 +59,10 @@ class Admins::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  protected
+  #情報更新後のリダイレクト先
+  def after_update_path_for(resource)
+    admin_items_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [:address])
     devise_parameter_sanitizer.permit(:account_update, keys: [:phone_number])
     devise_parameter_sanitizer.permit(:account_update, keys: [:email])
+    #管理者情報用
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
 end

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -1,4 +1,6 @@
-<h2>Forgot your password?</h2>
+<h2>パスワード再発行</h2>
+
+<p>登録したメールアドレスを入力してパスワードを再発行するを押してください。</p>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,8 +11,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワードを再発行する" %>
   </div>
 <% end %>
 
-<%= render "admins/shared/links" %>
+<%# render "admins/shared/links" %>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,43 +1,41 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h3>管理者情報編集</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :"名前" %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
   </div>
 
+  <div class="field">
+    <%= f.label :"メールアドレス" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.label :"新しいパスワード" %>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+    (<%= @minimum_password_length %> 文字以上)
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :"新しいパスワード（確認用）" %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "更新" %>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<%= link_to "キャンセル", admin_items_path %>

--- a/app/views/admins/shared/_links.html.erb
+++ b/app/views/admins/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <%# end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた方は再発行の手続きへ", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,18 @@
-<h2>Forgot your password?</h2>
+<h2>パスワード再発行</h2>
+
+<p>登録したメールアドレスを入力してパスワードを再発行するを押してください。</p>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :"メールアドレス" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワードを再発行する" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%# render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
   <% if devise_mapping.rememberable? %>
     <div class="field">
       <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= f.label "ログイン状態を保持する" %>
     </div>
   <% end %>
 
@@ -23,4 +23,4 @@
   </div>
 <% end %>
 
-<%! render "devise/shared/links" %>
+<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,12 +2,12 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
+<%# if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%# link_to "Sign up", new_registration_path(resource_name) %><br />
+<%# end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた方は再発行の手続きへ", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :admins, controllers: {
-    registrations: 'admins/registrations',
+    #registrations: 'admins/registrations',
     sessions:      'admins/sessions',
     passwords:     'admins/passwords'
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,14 +31,18 @@ Rails.application.routes.draw do
   resources :deliveries, only: [:create, :destroy]
 
   ## 管理者用
-  namespace :admin do
-    resources :items
+  # 認証されたadminのみadmin/以下のURLにアクセスできます
+  # admin以下のルートはnamespace以下に追加してください
+  authenticated :admin do
+    namespace :admin do
+      resources :items
+    end
   end
 
   devise_for :admins, controllers: {
     registrations: 'admins/registrations',
-    sessions:      'admins/sessions'
+    sessions:      'admins/sessions',
+    passwords:     'admins/passwords'
   }
 
 end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :admins, controllers: {
-    #registrations: 'admins/registrations',
+    registrations: 'admins/registrations',
     sessions:      'admins/sessions',
     passwords:     'admins/passwords'
   }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,13 +125,14 @@ end
   post_code: post_code,
   address: address,
   phone_number: phone_number)
+end
 
-## likes
-#10.times do |n|
-#  customer_id = "#{n+1}"
-#  item_id = "#{n+2}"
-#
-#  Like.create!(
-#  customer_id: customer_id,
-#  item_id: item_id)
-#end
+## Admin
+name = Gimei.first.kanji
+email = "admin@gmail.com"
+password = "password"
+
+Admin.create!(
+  name: name,
+  email: email,
+  password: password)


### PR DESCRIPTION
### AdminのURL直打ち禁止の設定
Adminでログインしないとadmin以下のURLにアクセスできないようにするために、
routes.rbに`authenticated :admin do `を追加しました。
コメントもしましたが、Adminのルーティングを設定する際は
`namespace :admin do `以下に設定してください。
https://github.com/gworks-github/naganoenbando/blob/291ed633b86e9eb045bc34f06a836096f8a85aaf/config/routes.rb#L32-L39

---
### パスワード再発行の画面を作成しました。
ユーザ用 app/views/devise/passwords/new.html.erb
Admin用 app/views/admins/passwords/new.html.erb

---
###  Adminの情報編集の画面を作成しました。
app/views/admins/registrations/edit.html.erb

