### PR TITLE
入荷予定商品一覧の追加（一覧からの登録は未実装）

### DIFF
--- a/app/controllers/admin/arrived_items_controller.rb
+++ b/app/controllers/admin/arrived_items_controller.rb
@@ -5,4 +5,5 @@ class Admin::ArrivedItemsController < ApplicationController
 
 	def create
 	end
+
 end

--- a/app/controllers/admin/ready_items_controller.rb
+++ b/app/controllers/admin/ready_items_controller.rb
@@ -6,18 +6,16 @@ class Admin::ReadyItemsController < ApplicationController
 		@arrived_items = ArrivedItem.new
 	end
 
-	def create
-		ready_item = ReadyItem.new(item_id: params[:id])
-		puts params[:id]
-		ready_item.save
-		redirect_to admin_items_path
-	end
+  def create
+    ready_item = ReadyItem.new(item_id: params[:id])
+    ready_item.save
+    redirect_to admin_items_path
+  end
 
 	def destroy
-		item = ReadyItem.find(params[:id])
-		puts item
-		puts params[:id]
-		item.destroy
-		redirect_to admin_ready_items_path
+    item = Item.find(params[:id])
+    ready_item = ReadyItem.find_by(item_id:item.id)
+    ready_item.destroy
+    redirect_to admin_ready_items_path
 	end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item < ApplicationRecord
 	has_many :cart_items, dependent: :destroy
 	has_many :disks, dependent: :destroy
 	has_many :arrived_items
+	has_many :ready_items
 	has_many :likes
 	belongs_to :genre
 	belongs_to :label

--- a/app/models/ready_item.rb
+++ b/app/models/ready_item.rb
@@ -1,2 +1,3 @@
 class ReadyItem < ApplicationRecord
+	belongs_to :item
 end

--- a/app/views/admin/ready_items/index.html.erb
+++ b/app/views/admin/ready_items/index.html.erb
@@ -3,6 +3,8 @@
 	<table class="table">
 		<thead>
 			<tr>
+				<th>No</th>
+				<th>アイテムID</th>
 				<th>ジャケット</th>
 				<th>タイトル</th>
 				<th>フォーマット</th>
@@ -15,18 +17,22 @@
 			</tr>
 		</thead>
 		<tbody>
-			<% @ready_items_id.each do |id| %>
+
+      <%= form_for(@arrived_items, url: admin_arrived_items_path) do |f| %>
+
+			<% @ready_items.each.with_index(1) do |item,idx| %>
 			<tr>
-				<td><%= id %></td>
-				<td><%= Item.find(id).id %></td>
-				<td><%#= item.name %></td>
-				<td><%#= item.format %></td>
-				<td><%#= Artist.find(item.artist_id).name %></td>
-				<td><%#= Label.find(item.label_id).name %></td>
-				<td><%#= Genre.find(item.genre_id).name %></td>
-				<td><%#= item.prices %></td>
-				<td><%#= text_field_tag :quantity %></td>
-				<td><%#= link_to "削除", admin_ready_item_path(item.id), method: :delete %></td>
+				<td><%= idx %></td>
+				<td><%= item.id %></td>
+				<td><%= item.jacket_image_id %></td>
+				<td><%= item.name %></td>
+				<td><%= item.format %></td>
+				<td><%= item.artist.name %></td>
+				<td><%= item.label.name %></td>
+				<td><%= item.genre.name %></td>
+				<td><%= item.prices %></td>
+				<td><%= f.number_field :quantity %></td>
+				<td><%= link_to "削除", admin_ready_item_path(item.id), method: :delete %></td>
 			</tr>
 		</tbody>
 		<% end %>
@@ -47,5 +53,7 @@
 			</tr>
 		</tbody>
 	</table>
-	<%= submit_tag "登録" %>
+	<%= f.submit "登録" %>
 </div>
+
+<% end %>


### PR DESCRIPTION
商品一覧から入荷予定商品一覧に追加できるようになりました。

同じ商品を入荷しても重複はしません。
また、入荷予定商品一覧から商品ごとに削除できます。

入荷予定商品一覧からの一括登録の機能は未実装です。
実装に時間がかかりそうな印象です。