### PR TITLE
在庫数による商品詳細の画面変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,6 +47,12 @@ class ItemsController < ApplicationController
     @likes_ranks = Item.find(Like.where(created_at:1.week.ago.beginning_of_day..Time.zone.now.end_of_day).group(:item_id).order(Arel.sql('count(item_id) desc')).limit(5).pluck(:item_id))
     @likes_ranks_count = @likes_ranks.map{|id| Like.where(item_id: id).count}
     @ranks_number = [*1..5]
+
+    #在庫数
+    arrived_item_quantity = ArrivedItem.arrived_item_quantity(params[:id])
+    order_item_quantity = OrderDetail.order_item_quantity(params[:id])
+    @stock = arrived_item_quantity.merge(order_item_quantity) {
+      |key,arrived,order| arrived - order }.values[0].to_i
   end
 
   def edit

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -74,13 +74,17 @@
 
 
     <%= form_for [@item,@cart_item], url: item_carts_path(@item), html: {method: :post} do |f| %>
-    <div class="row">
+      <div class="row">
         <div class="col-sm-12">
-           <%= f.select :quantity, options_for_select((1..29).to_a) %>
+          <% if @stock > 0 %>
+            <%= f.select :quantity, options_for_select((1..@stock).to_a) %>
             <%= f.hidden_field :item_id, :value => @item.id %>
         </div>
-    </div>
-    <%= f.submit "カートへ入れる", class: "btn", style: "color: blue;" %>
+      </div>
+      <%= f.submit "カートへ入れる", class: "btn", style: "color: blue;" %>
+    <% else %>
+      <label>入荷待ちです</label>
+    <% end %>
     <% end %>
 
     <% if customer_signed_in? %>


### PR DESCRIPTION
商品詳細で在庫数に合わせて画面の表示を変えました。

#### 在庫数が1個以上ある場合
商品数が1～在庫数まで選択できます。

#### 在庫数が0個以下の場合
カードボタンが押せず、「入荷待ちです」を表示させました。

ご意見ください。

在庫数が15個の場合
<img src="https://user-images.githubusercontent.com/55340978/69477122-ad29d480-0e25-11ea-89f7-b76220337fd7.png" width="600px">

在庫数が0個の場合
<img src="https://user-images.githubusercontent.com/55340978/69477064-0f360a00-0e25-11ea-8d35-bcc6cd7fe7c2.png"  width = "600px">