### PR TITLE
入荷一覧のカレンダー機能解決しました

### DIFF
--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -31,5 +31,5 @@
         <% end %>
     </tbody>
 </table>
-<%= link_to "入荷一覧", admin_ready_items_path %>
+<%= link_to "入荷一覧", admin_ready_items_path, data: {"turbolinks" => false} %>
 </div>


### PR DESCRIPTION
turbolinksが悪さをしていました。
いまさらtubolinksを削除できないので、
入荷一覧を表示させるときだけtorbolinkを無効にしました。