### PR TITLE
マイページのお届け先追加のエラーメッセージ

### DIFF
--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -1,9 +1,18 @@
 class DeliveriesController < ApplicationController
   def create
-    delivery = current_customer.deliveries.new(delivery_params)
-  	delivery.save
-    redirect_to show_customer_path(id: delivery.customer_id)
+    @deli = current_customer.deliveries.new(delivery_params)
+
+    if @deli.save
+      redirect_to show_customer_path(id: @deli.customer_id)
+    else
+      # users/showでerrors.full_messagesをつかるようにするためrenderで引数を渡す
+      @customer   = Customer.find(current_customer.id)
+      @deliveries = @customer.deliveries
+      @delivery   = @customer.deliveries.new
+      render("users/show")
+    end
   end
+
   def destroy
     delivery = current_customer.deliveries.find(params[:id])
     delivery.destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
   def show
     @deliveries = @customer.deliveries
     @delivery   = @customer.deliveries.new
+    @deli       = @customer.deliveries.new #error_check用
   end
 
   def destroy

--- a/app/views/layouts/_error_message.html.erb
+++ b/app/views/layouts/_error_message.html.erb
@@ -1,0 +1,7 @@
+<% if model.errors.any? %>
+  <% model.errors.full_messages.each do |err_msg| %>
+    <div class="error_field alert alert-danger" role="alert">
+      <p class="error_msg"><%= err_msg %></p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,13 @@
 <h1 class="title">マイページ</h1>
 
+
 <div class="container mypage">
   <div class="row">
     <div class="col-sm-1">
-        <%= link_to "購入履歴", orders_path, class:"btn btn-lg" %> <br>
-        <%= link_to "いいねした商品", likes_path, class:"btn btn-lg" %> <br>
+        <%= link_to "購入履歴", orders_path(current_customer.id), class:"btn btn-lg" %> <br>
+        <%= link_to "いいねした商品", likes_path(current_customer.id), class:"btn btn-lg" %> <br>
         <%# "deletメソッドを使用しているが、実際はdevise/registrationへのリダイレクトのみ%>
-        <%= link_to "退会手続き", destroy_customer_path, method: :delete, class:"btn btn-lg"%> <br>
+        <%= link_to "退会手続き", destroy_customer_path(current_customer.id), method: :delete, class:"btn btn-lg"%> <br>
     </div>
 
       <div class="row">
@@ -53,6 +54,7 @@
         <% end %>
       <% end %>
 
+<%= render 'layouts/error_message', model: @deli %>
       <div class="row">
         <div class="col-sm-8">
           <button class="btn add-button">お届け先を追加する</button>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,15 @@
+en:
+  activerecord:
+    attributes:
+      delivery:
+        customer_id: ID
+        email: メールアドレス
+        first_furigana: フリガナ(名)
+        last_furigana: フリガナ(姓)
+        post_code: 郵便番号
+        address: 住所
+        phone_number: 電話番号
+        first_name: 名前(名)
+        last_name: 名前(姓)
+    models:
+        delivery: お届け先


### PR DESCRIPTION
マイページのお届け先追加で、
登録がエラーになったときのメッセージを表示させました。
カラムの日本語化のためconfig/locales/ja.ymlを作成しました。

![スクリーンショット (15)](https://user-images.githubusercontent.com/55340978/69522600-27cd2e00-0fa5-11ea-9893-3bf9fa37997d.png)
