### PR TITLE
マイページのお届け先追加のエラーメッセージ　再対応

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Naganoenbando
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/cust.yml
+++ b/config/locales/cust.yml
@@ -1,0 +1,36 @@
+ja:
+  activerecord:
+    attributes:
+      customer:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+        email: メールアドレス
+        first_name: 名前(名)
+        last_name: 名前(姓)
+        first_furigana: フリガナ(名)
+        last_furigana: フリガナ(姓)
+        post_code: 郵便番号
+        address: 住所
+        phone_number: 電話番号
+    models:
+        customer: ユーザ

--- a/config/locales/deli.yml
+++ b/config/locales/deli.yml
@@ -1,9 +1,8 @@
-en:
+ja:
   activerecord:
     attributes:
       delivery:
         customer_id: ID
-        email: メールアドレス
         first_furigana: フリガナ(名)
         last_furigana: フリガナ(姓)
         post_code: 郵便番号
@@ -11,5 +10,7 @@ en:
         phone_number: 電話番号
         first_name: 名前(名)
         last_name: 名前(姓)
+        created_at: 作成日
+        updated_at: 更新日
     models:
-        delivery: お届け先
+       delivery: お届け先

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,6 +1,4 @@
-# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
-
-en:
+ja:
   activerecord:
     attributes:
       customer:


### PR DESCRIPTION
下記↓の日本語化対応がまたうまくいかなくなってしまったので修正しました。

マイページのお届け先追加のエラーメッセージ #105